### PR TITLE
[#92] refactor : Ignoring the case-sensitive query for the 'searchBy' and 'search' functionality.

### DIFF
--- a/server/posts/post.service.js
+++ b/server/posts/post.service.js
@@ -17,6 +17,14 @@ async function getAll() {
     return posts.map(x => basicDetails(x));
 }
 
+/**
+ * Providing 'searchBy' functionality;
+ * 
+ * Here we apply a regex based search logic to let the query
+ * to match all records with ignoring case-sensitive aspect.
+ * 
+ * @param {Object} query The native express-query object.
+ */
 async function handleQuery(query) {
     if (!!query.searchBy || !!query.search) {
         if (!query.searchBy) throw `No any 'searchBy' value provided!`
@@ -24,7 +32,8 @@ async function handleQuery(query) {
 
         const posts = await db.PostMessage.find({
             [query.searchBy]: {
-                $regex: '.*' + query.search + '.*' 
+                $regex: query.search,
+                $options: 'i' 
             } 
         });
 

--- a/server/server.js
+++ b/server/server.js
@@ -29,13 +29,13 @@ app.use(cors({ origin: (origin, callback) => callback(null, true), credentials: 
 // Welcome the visitors...
 app.get('/', (req, res) => {
     res.send(`
-        Hello to TechNotes API... 
-        
+        <h1> Hello to TechNotes API... </h1> 
+        <br />
         Please ensure to request to deployed API!...
-        @ https://technotes-api-main.herokuapp.com/
-
+        @ <a href="https://technotes-api-main.herokuapp.com/"> https://technotes-api-main.herokuapp.com/ </a>
+        <br /> <hr />
         API doc enabled!
-        @ https://technotes-api-main.herokuapp.com/api-docs/
+        @ <a href="https://technotes-api-main.herokuapp.com/api-docs/"> https://technotes-api-main.herokuapp.com/api-docs/ </a>
     `);
 });
 

--- a/server/swagger.yaml
+++ b/server/swagger.yaml
@@ -900,7 +900,7 @@ paths:
           $ref: "#/components/responses/NotFoundError"
         "401":
           $ref: "#/components/responses/UnauthorizedError"
-  /api/posts/{searchBy}:
+  /api/posts?{searchBy}&{search}:
     parameters:
       - in: path
         name: searchBy


### PR DESCRIPTION
[#92] refactor : Ignoring the case-sensitive query for the 'searchBy' and 'search' functionality.

Here after consumers can query the values to get all matched records within ignoring case-sensitive process. Thus they will be able to see data with matches like; 'foo', 'Foo', 'fOO' etc.

Material: https://nimb.ws/OrG3K0