### PR TITLE
[#114] docs : Missing documentation notation for the `page` params on get all Posts has been provided.

### DIFF
--- a/server/swagger.yaml
+++ b/server/swagger.yaml
@@ -643,6 +643,13 @@ paths:
           $ref: "#/components/responses/UnauthorizedError"
 
   /api/posts:
+    parameters:
+      - in: path
+        name: page
+        description: Pagination number, defaults to 1. Data response will be 24 records.
+        example: "1"
+        schema:
+          type: number
     get:
       summary: Get a list of all post messages
       description: Restricted to admin users.


### PR DESCRIPTION
Material: https://nimb.ws/dtW2vR